### PR TITLE
[Feature] Add delete icon and navigate back after clicking

### DIFF
--- a/android/app/src/main/java/co/nimblehq/smsforwarder/ui/screens/filter/manager/FilterManagerFragment.kt
+++ b/android/app/src/main/java/co/nimblehq/smsforwarder/ui/screens/filter/manager/FilterManagerFragment.kt
@@ -1,10 +1,12 @@
 package co.nimblehq.smsforwarder.ui.screens.filter.manager
 
-import android.view.LayoutInflater
-import android.view.ViewGroup
+import android.os.Bundle
+import android.view.*
 import androidx.fragment.app.viewModels
+import co.nimblehq.smsforwarder.R
 import co.nimblehq.smsforwarder.databinding.FragmentFilterManagerBinding
 import co.nimblehq.smsforwarder.extension.subscribeOnClick
+import co.nimblehq.smsforwarder.extension.toastShort
 import co.nimblehq.smsforwarder.ui.base.BaseFragment
 import co.nimblehq.smsforwarder.ui.helpers.handleVisualOverlaps
 import co.nimblehq.smsforwarder.ui.screens.MainNavigator
@@ -19,6 +21,15 @@ class FilterManagerFragment : BaseFragment<FragmentFilterManagerBinding>() {
 
     private val viewModel by viewModels<FilterManagerViewModel>()
 
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        setHasOptionsMenu(true)
+        return super.onCreateView(inflater, container, savedInstanceState)
+    }
+
     override val bindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> FragmentFilterManagerBinding
         get() = { inflater, container, attachToParent ->
             FragmentFilterManagerBinding.inflate(inflater, container, attachToParent)
@@ -32,6 +43,20 @@ class FilterManagerFragment : BaseFragment<FragmentFilterManagerBinding>() {
                 .subscribeOnClick(navigator::navigateUp)
                 .addToDisposables()
         }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.delete_filter_menu, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == R.id.deleteFilter) {
+            // TODO: Implement delete filter
+            toastShort("Delete filter")
+            navigator.navigateUp()
+            return true
+        }
+        return false
     }
 
     override fun handleVisualOverlaps() {

--- a/android/app/src/main/res/drawable/ic_delete.xml
+++ b/android/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
+</vector>

--- a/android/app/src/main/res/menu/delete_filter_menu.xml
+++ b/android/app/src/main/res/menu/delete_filter_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/deleteFilter"
+        android:icon="@drawable/ic_delete"
+        android:title="@string/menu_add_filter"
+        app:showAsAction="ifRoom" />
+</menu>


### PR DESCRIPTION
https://github.com/nimblehq/sms-forwarder/issues/51

## What happened 👀

To support the delete filter feature, we need to add the delete icon.

## Insight 📝

- Add the delete icon at the Action Bar of the FilterManager screen
- Add onClickListener to navigate back to AllFiltersFragment after clicking delete icon
 
## Proof Of Work 📹

<img src="https://user-images.githubusercontent.com/12026942/127522469-e8f8bde2-9d3a-45af-9571-aebf292a28b7.gif" width=200 />

