### PR TITLE
[#29] Add forward to slack channel API

### DIFF
--- a/web/api/app.js
+++ b/web/api/app.js
@@ -5,31 +5,67 @@ let config = require('../config/config.json');
 let ApiExt = require('./api-ext');
 
 let mailer = require('../services/mailer');
+let slack = require('../services/slack');
 
 router.post('/v1/sms/forward', function (req, res) {
-  req.checkBody('incoming_number').optional().len({min: 0, max: 100});
-  req.checkBody('message_body').notEmpty().len({min: 1, max: 1000});
-  req.checkBody('email').optional().len({min: 0, max: 1000}).isEmail();
-  req.checkBody('slack_webhook').optional().len({min: 0, max: 1000}).isURL();
+  req.checkBody('incoming_number').optional().len({
+    min: 0,
+    max: 100
+  });
+  req.checkBody('message_body').notEmpty().len({
+    min: 1,
+    max: 1000
+  });
+  req.checkBody('email').optional().len({
+    min: 0,
+    max: 1000
+  }).isEmail();
+  req.checkBody('slack_webhook').optional().len({
+    min: 0,
+    max: 1000
+  }).isURL();
 
   req.sanitizeBody('email').toLowerCase();
 
   ApiExt.validateRequest(req, res, function () {
+    let incomingNumber = req.body.incoming_number;
+    let messageBody = req.body.message_body;
+
     let binder = {
       email: req.body.email,
       subject: 'New SMS message - ' + config.app_name,
-      incoming_number: req.body.incoming_number,
-      message_body: req.body.message_body
+      incoming_number: incomingNumber,
+      message_body: messageBody
     };
-    mailer.send('forgot-password', binder, function (err, response, html, text) {
-      if (err) {
-        console.log(err);
-        ApiExt.buildFailedResponse(res, err.message);
-      } else {
-        ApiExt.buildSuccessResponse(res, 'The SMS message has been forwarded to ' + req.body.email);
+    mailer.send('forgot-password', binder, function (error, response, html, text) {
+      if (error) {
+        console.log(error);
       }
+      forwardToSlack(res, error, req.body.slack_webhook, incomingNumber, messageBody);
     });
   });
 });
+
+function forwardToSlack(res, emailError, slackWebhookUrl, incomingNumber, messageBody) {
+  slack.sendMessage(slackWebhookUrl, incomingNumber, messageBody, function (error) {
+    if (error) {
+      console.log(error);
+    }
+    buildResponse(res, emailError && error)
+  })
+}
+
+function buildResponse(res, emailError, slackApiErr) {
+  var error;
+  if(emailError) error = emailError
+  else error = slackApiErr;
+
+  if (error) {
+    console.log(error);
+    ApiExt.buildFailedResponse(res, error.message);
+  } else {
+    ApiExt.buildSuccessResponse(res, 'The SMS message has been forwarded');
+  }
+}
 
 module.exports = router;

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,5 @@
     "request": "^2.88.0",
     "sequelize": "^3.30.4",
     "sequelize-cli": "^2.7.0"
-  },
-  "devDependencies": {}
+  }
 }

--- a/web/services/slack.js
+++ b/web/services/slack.js
@@ -1,0 +1,25 @@
+const env = process.env.NODE_ENV || 'development';
+const config = require('../config/config.json')[env];
+const request = require('request');
+
+exports.sendMessage = function (slackWebhookUrl, incomingNumber, messageBody, callback) {
+  let json = {
+    text: 'New SMS message',
+    attachments: [{
+      fields: [{
+        title: incomingNumber,
+        value: messageBody,
+        short: false
+      }]
+    }]
+  };
+
+  request
+    .post(
+      slackWebhookUrl, {
+        json: json
+      },
+      function (error, response, body) {
+        callback(error);
+      });
+}


### PR DESCRIPTION
#29

## What happened 👀

We need the backend to forward SMS to a Slack channel.
 
## Insight 📝

- We use Slack Webhook to send messages to a Slack channel.
- The message json will look like this:

```
  let json = {
    text: 'New SMS message',
    attachments: [{
      fields: [{
        title: incomingNumber,
        value: messageBody,
        short: false
      }]
    }]
  };
```
 
## Proof Of Work 📹

API Documentation: https://documenter.getpostman.com/view/6401217/TzseHkXG#d1f9b0a8-29f6-45d0-b0a5-776482d6dd8e

![image](https://user-images.githubusercontent.com/16315358/127524796-38bdeecf-4d81-413a-9460-099230f484f1.png)

![image](https://user-images.githubusercontent.com/16315358/127524948-c8f99672-b57a-4f88-8692-3ca0d3f606e4.png)


