### PR TITLE
[#54] [API] As a developer, I need an basic authentication layer at the beginning to secure the APIs

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -12,6 +12,7 @@ const User = require('./models').User;
 const basicAuth = require('express-basic-auth')
 app.use(basicAuth({
   authorizer: asyncAuthorizer,
+  unauthorizedResponse: getUnauthorizedResponse,
   authorizeAsync: true,
   challenge: true
 }))
@@ -68,6 +69,20 @@ function asyncAuthorizer(username, password, callback) {
       return callback(null, false)
     }
   });
+}
+
+function getUnauthorizedResponse(req) {
+  return req.auth ?
+    buildFailedResponse('Credentials ' + req.auth.user + ':' + req.auth.password + ' rejected') :
+    buildFailedResponse('No credentials provided')
+}
+
+function buildFailedResponse(message) {
+  return {
+    message: message,
+    success: 0,
+    data: null
+  };
 }
 
 module.exports = app;

--- a/web/app.js
+++ b/web/app.js
@@ -6,6 +6,15 @@ var express = require('express'),
   expressValidator = require('express-validator'),
   app = express();
 
+// basic authentication https://www.npmjs.com/package/express-basic-auth
+const basicAuth = require('express-basic-auth')
+app.use(basicAuth({
+  users: {
+    'admin': '123456'
+  },
+  challenge: true
+}))
+
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'pug');
@@ -44,6 +53,8 @@ app.use(function (err, req, res, next) {
   res.status(err.status || 500);
   res.render('error');
 });
+
+
 
 // TODO Test code, will be updated in https://github.com/nimblehq/sms-forwarder/issues/54
 const User = require('./models').User;

--- a/web/app.js
+++ b/web/app.js
@@ -6,12 +6,13 @@ var express = require('express'),
   expressValidator = require('express-validator'),
   app = express();
 
+const User = require('./models').User;
+
 // basic authentication https://www.npmjs.com/package/express-basic-auth
 const basicAuth = require('express-basic-auth')
 app.use(basicAuth({
-  users: {
-    'admin': '123456'
-  },
+  authorizer: asyncAuthorizer,
+  authorizeAsync: true,
   challenge: true
 }))
 
@@ -54,12 +55,19 @@ app.use(function (err, req, res, next) {
   res.render('error');
 });
 
-
-
-// TODO Test code, will be updated in https://github.com/nimblehq/sms-forwarder/issues/54
-const User = require('./models').User;
-User.findAll().then(function (users) {
-  console.log(users.length);
-});
+function asyncAuthorizer(username, password, callback) {
+  User.findOne({
+    where: {
+      username: username,
+      password: password
+    }
+  }).then(function (user) {
+    if (user) {
+      return callback(null, true)
+    } else {
+      return callback(null, false)
+    }
+  });
+}
 
 module.exports = app;

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
     "debug": "~2.6.9",
     "email-templates": "^2.6.0",
     "express": "~4.16.0",
+    "express-basic-auth": "^1.2.0",
     "express-validator": "^3.2.0",
     "http-errors": "~1.6.2",
     "morgan": "~1.9.0",


### PR DESCRIPTION
#54

## What happened 👀

While waiting for #28, #32 and #42 to be implemented, at the beginning we could use basic authentication mechanism to secure the APIs.
 
## Insight 📝

- Use a [basic authentication](https://www.npmjs.com/package/express-basic-auth) mechanism to secure all API requests.
- Verify user credentials by the data in the `User` table in DB.
- Invalid authentication will return 401.
 
## Proof Of Work 📹

![image](https://user-images.githubusercontent.com/16315358/127551339-61145338-a93e-402d-8f64-d64279df764b.png)

![image](https://user-images.githubusercontent.com/16315358/127551402-85cfee0f-a80e-432a-9179-9f5b008df09d.png)

![image](https://user-images.githubusercontent.com/16315358/127554009-20ff66c4-1ab0-44a4-ab47-a83927b80bde.png)


![image](https://user-images.githubusercontent.com/16315358/127551455-f50c8479-dd2a-4fa3-b145-af51134a8dcc.png)

